### PR TITLE
fix: don't override people's root EditorConfig config through this repo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,3 @@
-# top-most EditorConfig file
-root = true
-
 [*]
 end_of_line = lf
 charset = utf-8


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting since someone might have pushed the same thing before!

This template is entirely optional and can be removed, but is here to help both you and us.
Provide a general summary of your changes in the title above.
Anything on lines wrapped in comments like these will not show up in the final text.
-->

# ↪️ Pull Request

<!--
Put an `x` into the [ ] to show you have filled the information
-->

- [x] Make sure you are opening from a **feature/feat/docs/fix/bug/hotfix/stable/chore** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry

## 📒 Description
Hi there,

The `.editorconfig` file in this repo sets `root = true`, which shouldn't be the case in a repo such as this, as it overrides people's config when they use EditorConfig (see EditorConfig docs [here](https://editorconfig.org/)). Typically, only one `.editorconfig` file has `root = true` and that particular file is located in the user's home directory so that it applies desired settings globally for the user. EditorConfig will use the user's root `.editorconfig`, while the `.editorconfig` in this repo can apply additional settings not covered in the user's root config, or override the user's root config (for example if they have `indent_size = 4` set globally in their root config, the config in this repo would override that to 2 to respect your desired style.

I believe that's how you intended this to work, but unfortunately setting `root = true` in the file here effectively breaks EditorConfig as it prevents one's personal root file from being used. People like me may have settings in their root config that don't conflict with the config file in this repo, but won't be used because this repo's `.editorconfig` is set to be the root, so any `.editorconfig` file located higher in the directory tree won't be read at all.

## 🕶️ Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
<!-- - **Bug fix** (non-breaking change which fixes an issue) -->
<!-- - **New feature** (non-breaking change which adds functionality) -->
<!-- - **Breaking change** (fix or feature that would cause existing functionality to change) -->

- [ ] Core
- [x] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Documentation
- [ ] Dependencies

### 🤯 List of changes
Remove `root = true` from the EditorConfig config file

### 👫 Relationships
N/A

<!-- If you want to close the main issue automatically after PR is merged -->
<!-- https://help.github.com/articles/closing-issues-using-keywords/ -->

<!-- Closes #your_issue_number -->

### 🔎 Review hints
N/A
<!-- Tips to the reviewer about how this should be tested -->

## 🚨 Test instructions
N/A
<!-- In case it is impossible (or too hard) to reliably test this feature/fix with unit tests, please provide test instructions! -->

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the [**CONTRIBUTING** document](https://github.com/ivankatliarchuk/.github/blob/main/contributing.md).
- [ ] Added/updated unit tests for this change
- [x] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
- [ ] Filled out test instructions (In case there aren't any unit tests)
- [x] I followed the existing code standards and didn't mess up the formatting.
- [ ] My change requires a change to the documentation.
- [ ] I did my best to add documentation to any public classes or methods I added.
- [ ] Included links to related issues/PRs
